### PR TITLE
quick hack to give guess-results at redirected search queries

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,29 @@
+---
+layout: page
+permalink: /404.html
+title: 404
+---
+
+Oh no! This page isn't here anymore, or maybe it was never here!
+
+Were you looking for this?
+
+<ul id="search-results"></ul>
+
+<script>
+  window.store = {
+    {% for post in site.artifacts %}
+      "{{ post.url | slugify }}": {
+        "title": "{{ post.title }}",
+        "namevar": {{ post.namevar | jsonify }},
+        "categories": {{ post.categories | jsonify }},
+        "tags": {{ post.tags | jsonify }},
+        "content": {{ post.content | strip_html | strip_newlines | jsonify }},
+        "url": "{{ site.baseurl }}{{ post.url }}"
+      }
+      {% unless forloop.last %},{% endunless %}
+    {% endfor %}
+  };
+</script>
+<script src="{{ site.baseurl }}/js/lunr.min.js"></script>
+<script src="{{ site.baseurl }}/js/404search.js"></script>

--- a/js/404search.js
+++ b/js/404search.js
@@ -31,9 +31,8 @@
     }
   }
 
-  var searchTerm = getQueryVariable('query');
+  var searchTerm = window.location.pathname.split('/')[window.location.pathname.split('/').length-1].replace('_',' ');
   if (searchTerm) {
-    document.getElementById('search-box').setAttribute("value", searchTerm);
 
     // Initalize lunr with the fields it will be searching on. I've given title
     // and namevar a boost of 10 to indicate matches on this field are more important.


### PR DESCRIPTION
This adds a 404 page and also searches for what could be a potential valid close-to-redirect, if someone is hitting an old MediaWiki link.

This code should definitely be optimized, but I want to try it out before cutting it down to one simple search in case other optimization is needed. Also it's a Friday night and I'm lazy.

Resolves #22 and helps with #23 