### PR TITLE
removes unusual hidden character in links

### DIFF
--- a/_artifacts/head_switching_noise.md
+++ b/_artifacts/head_switching_noise.md
@@ -21,12 +21,12 @@ Even with one of these VCRs, 480i capture devices following SMPTE RP 202's stand
 
 Playback from a normal VHS VCR into a card that captures from line 23, showing normal switching noise.
 
-<img src="{{ site.baseurl }}/images/HeadSwitch_Butterfly_SLV-779HF_Sharp1_XCard.jpg‎">
+<img src="{{ site.baseurl }}/images/HeadSwitch_Butterfly_SLV-779HF_Sharp1_XCard.jpg">
 
 Playback from a JVC BR-S525U into a card that captures from line 23, showing black at the bottom of the image.
 
-<img src="{{ site.baseurl }}/images/HeadSwitch_Butterfly_BR-S525U_XCard1_PB4.5H.jpg‎">
+<img src="{{ site.baseurl }}/images/HeadSwitch_Butterfly_BR-S525U_XCard1_PB4.5H.jpg">
 
 Playback from a JVC BR-S525U into a card that captures from line 22, showing no switching noise. (The bending is because this card has no TBC.)
 
-<img src="{{ site.baseurl }}/images/HeadSwitch_Butterfly_BR-S525U_VC500.jpg‎">
+<img src="{{ site.baseurl }}/images/HeadSwitch_Butterfly_BR-S525U_VC500.jpg">


### PR DESCRIPTION
Very unusual and not visible inside of a text editor. `git blame` suggests this came from... me!!!!???

<img width="795" alt="screen shot 2017-02-04 at 12 04 02" src="https://cloud.githubusercontent.com/assets/3260492/22620131/88b3ff14-ead2-11e6-83d8-81afab5f52ca.png">
