### PR TITLE
Adding new Artifact PCM F1 Audio

### DIFF
--- a/_artifacts/pcm_f1_Audio_without_adaptor.md
+++ b/_artifacts/pcm_f1_Audio_without_adaptor.md
@@ -6,7 +6,7 @@ namevar: [PCM, F1, digital audio]
 tags: [Audio, Digital, U-matic, Betamax]
 ---
 
-PCM F1 Audio without Adaptor refers to a digtial audio signal that is recorded onto an analog video tape. It appears as grey and black blocks that scroll vertically across the screen and looks similar to a barcode. It can appear on any video format, but is most frequently seen on U-matic and Betamax tapes. The Sony PCM-1600/1610/1630 adaptor were most commonly used with U-matic, and the Sony PCM-F1 adaptor with Betamax.
+PCM F1 Audio without Adaptor refers to a digtial audio signal that is recorded onto an analog video tape. It appears as grey and black blocks that scroll vertically across the screen and looks similar to a barcode. It can appear on any video format, but is most frequently seen on U-matic and Betamax tapes. The [Sony PCM-1600/1610/1630](https://en.wikipedia.org/wiki/PCM_adaptor) adaptor were most commonly used with U-matic, and the Sony PCM-F1 adaptor with Betamax.
 
 [According to greatbear](http://www.thegreatbear.net/audio-tape/early-digital-tape-recordings-umatic-betamax-video-tape/), this hybrid analog/digital system was the first two-channel stereo digital recording process, combining the transport and recording mechanisms of the VTR with a PCM (pulse-code-modulation) digital processor. Remarkably, this set the precedent for the 44.1 kHz audio sampling rate that was used with CD recording.
 

--- a/_artifacts/pcm_f1_Audio_without_adaptor.md
+++ b/_artifacts/pcm_f1_Audio_without_adaptor.md
@@ -1,0 +1,19 @@
+---
+layout: post
+title: PCM F1 Audio without Adaptor
+categories: audio digital
+namevar: [PCM, F1, digital audio]
+tags: [Audio, Digital, U-Matic, Betamax]
+---
+
+PCM F1 Audio without Adaptor refers to a digtial audio signal that is recorded onto an analog video tape. It appears as grey and black blocks that scroll vertically across the screen and looks similar to a barcode. It can appear on any video format, but is most frequently seen on U-Matic and Betamax tapes. The Sony PCM-1600/1610/1630 adaptor were most commonly used with U-Matic, and the Sony PCM-F1 adaptor with Betamax.
+
+[According to greatbear](http://www.thegreatbear.net/audio-tape/early-digital-tape-recordings-umatic-betamax-video-tape/), this hybrid analog/digital system was the first two-channel stereo digital recording process, combining the transport and recording mechanisms of the VTR with a PCM (pulse-code-modulation) digital processor. Remarkably, this set the precedent for the 44.1 kHz audio sampling rate that was used with CD recording.
+
+## Can it be fixed?
+
+Yes. It can be fixed by adding the appropriate adaptor to your video signal chain.
+
+## Examples
+
+<iframe src="https://archive.org/embed/Pcm-f1audioWithoutAdapter" width="560" height="315" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen></iframe>

--- a/_artifacts/pcm_f1_Audio_without_adaptor.md
+++ b/_artifacts/pcm_f1_Audio_without_adaptor.md
@@ -3,10 +3,10 @@ layout: post
 title: PCM F1 Audio without Adaptor
 categories: audio digital
 namevar: [PCM, F1, digital audio]
-tags: [Audio, Digital, U-Matic, Betamax]
+tags: [Audio, Digital, U-matic, Betamax]
 ---
 
-PCM F1 Audio without Adaptor refers to a digtial audio signal that is recorded onto an analog video tape. It appears as grey and black blocks that scroll vertically across the screen and looks similar to a barcode. It can appear on any video format, but is most frequently seen on U-Matic and Betamax tapes. The Sony PCM-1600/1610/1630 adaptor were most commonly used with U-Matic, and the Sony PCM-F1 adaptor with Betamax.
+PCM F1 Audio without Adaptor refers to a digtial audio signal that is recorded onto an analog video tape. It appears as grey and black blocks that scroll vertically across the screen and looks similar to a barcode. It can appear on any video format, but is most frequently seen on U-matic and Betamax tapes. The Sony PCM-1600/1610/1630 adaptor were most commonly used with U-matic, and the Sony PCM-F1 adaptor with Betamax.
 
 [According to greatbear](http://www.thegreatbear.net/audio-tape/early-digital-tape-recordings-umatic-betamax-video-tape/), this hybrid analog/digital system was the first two-channel stereo digital recording process, combining the transport and recording mechanisms of the VTR with a PCM (pulse-code-modulation) digital processor. Remarkably, this set the precedent for the 44.1 kHz audio sampling rate that was used with CD recording.
 


### PR DESCRIPTION
Added a new artifact describing the PCM F1 Audio without Adaptor that occurs on some umatic and betamax tapes.