### PR TITLE
Added "Luminance Blooming" example to "Image Lag" page

### DIFF
--- a/_artifacts/image_lag.md
+++ b/_artifacts/image_lag.md
@@ -12,7 +12,7 @@ Image lag occurs in video recorded or displayed using certain types of pick-up d
 
 In instances where comet tails or luma trails are visible, the visual artifact is sometimes referred to as "ghost" or "ghosting." [Ghost]({{ site.baseurl }}/artifacts/ghost.html) also refers to an artifact of video transmission when there is a difference in primary and secondary radio frequency signals.
 
-Aside from causing Image Lag, issues with Vidicon tubes can also caused bright portions of the image to appear as white blobs which are sometimes larger than the original bright object or light source. This artifact is referred to as "Luminance Blooming", and it is often seen conjunction with Image Lag
+Aside from causing Image Lag, issues with Vidicon tubes can also caused bright portions of the image to appear as white blobs which are sometimes larger than the original bright object or light source. This artifact is referred to as "Luminance Blooming", and it is often seen conjunction with Image Lag.
 
 ## Can it be fixed?
 

--- a/_artifacts/image_lag.md
+++ b/_artifacts/image_lag.md
@@ -2,8 +2,8 @@
 layout: post
 title: Image Lag
 categories: video analog
-namevar: [Ghosting, Smearing, Burn-in, Comet Tails, Luma Trails]
-tags: [Ghosting, Smearing, Comet Tails, Tape Error, Analog, Video]
+namevar: [Ghosting, Smearing, Burn-in, Comet Tails, Luma Trails, Luminance Blooming]
+tags: [Ghosting, Smearing, Comet Tails, Tape Error, Analog, Video, Luminance Blooming]
 ---
 
 Image lag occurs in video recorded or displayed using certain types of pick-up devices and cameras, including the Vidicon picture tube, among others. This type of camera tube captures light radiating from a scene through a lens and projects it onto a photoconductive target, creating a charge-density pattern which is scanned using low-velocity electrons. The resulting image can be amplified and recorded to tape or output to a video monitor. The electrical charge remains present on the target until it is [re-scanned or the charge dissipates](http://en.wikipedia.org/wiki/Video_camera_tube).
@@ -11,6 +11,8 @@ Image lag occurs in video recorded or displayed using certain types of pick-up d
 <blockquote>The time delay in establishing a new signal current in the camera to follow the rapid changes in the target illumination is called 'image lag' or simply 'lag'. In the photoconductive camera tubes this occurs in two forms: (i) photoconductive lag determined by the properties of the target materials, and (ii) capacitive lag or beam lag attributed to the storage effect of the pixel capacitance and the beam resistance. The image lag causes smear or comet tails following fast-moving objects in the scene, and the prolonged exposure of a bright stationary object results in a slow decaying after image of x-ray type appearance. This long-term but faint after-image is called burn-in or picture sticking.<sup><a href="#fn1" id="ref1">1</a></sup></blockquote>    
 
 In instances where comet tails or luma trails are visible, the visual artifact is sometimes referred to as "ghost" or "ghosting." [Ghost]({{ site.baseurl }}/artifacts/ghost.html) also refers to an artifact of video transmission when there is a difference in primary and secondary radio frequency signals.
+
+Aside from causing Image Lag, issues with Vidicon tubes can also caused bright portions of the image to appear as white blobs which are sometimes larger than the original bright object or light source. This artifact is referred to as "Luminance Blooming", and it is often seen conjunction with Image Lag
 
 ## Can it be fixed?
 
@@ -20,6 +22,9 @@ Image lag is not a fixable artifact, but rather a result of the inherent limits 
 
 <iframe src="https://archive.org/embed/AVAAAvaaGhostTest03" width="560" height="315" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen></iframe><br>
 <sub>Comet Tails are visible when the camera shifts, and a white aura appears around the head of the singer as he moves. (Walter Steding Concerts 1980s, _XFR STN Project_; [Internet Archive](https://archive.org/details/XFR_2013-07-27_1A_01), 2013).</sub>
+
+<iframe src="https://archive.org/embed/LuminanceBloom" width="560" height="315" frameborder="0" webkitallowfullscreen="true" mozallowfullscreen="true" allowfullscreen></iframe><br>
+<sub>The light from the lamp is too bright for the Vidicon tube, and the bright image exhibits luminance blooming. Once the light is turned off the luminance blooming slowly dissipates as the Vidicon tube slowly discharges. (La MaMa Experimental Theater Club; [Internet Archive]).</sub>
 
 ## References
 


### PR DESCRIPTION
After much deliberation, I've decided to make "Luminance Blooming" a sub-artifact of Image Lag. This is because it's caused by the same issue.