### PR TITLE
Examples for Low RF

### DIFF
--- a/_artifacts/low_rf.md
+++ b/_artifacts/low_rf.md
@@ -11,3 +11,12 @@ This term describes a low level off-tape signal. This can be due to a poorly mad
 
 If oxide build-up on the tape heads is causing this issue, then yes, cleaning the heads should help. If the source media itself has been exposed to a strong magnetic field (unshielded speakers, motors, high-voltage transformers, etc.) that has caused RF to drop, then there is no remedy for this problem.
 
+## Example(s)
+
+Images below illustrate the difference between a 'normal' RF envelope, a partial head clog (right side of waveform indicating initial head clog) and full head clog. This example is caused by sticky-shed syndrome and oxide particles clogging the video heads.
+
+<img src="http://erikpiil.com/assets/img/normalrf1.jpg"><img src="http://erikpiil.com/assets/img/rf_partialheadclog1.jpg"><img src="http://erikpiil.com/assets/img/rf_fullheadclog1.jpg">
+
+## References
+
+<sup id="fn1">1. Erik Piil, _["RF, A Scope for Video Preservation"](http://erikpiil.com/2014/07/14/rf-a-scope-for-video-preservation.html)_ Erikpiil.com, 2014</sup>


### PR DESCRIPTION
Researching Low RF signals today and found a really helpful blog from 2014 with nice imagery that shows normal RF envelope degrade to low RF envelope via sticky shed syndrome. Thought it could be useful to have as an illustration.. up to you @ablwr if you think it's appropriate to include :) 

Also, I love the sticker "Analog isn't easy".