### PR TITLE
Add namevars to formats

### DIFF
--- a/formats.html
+++ b/formats.html
@@ -2,14 +2,20 @@
 layout: page
 title: Formats
 ---
-<h3>Related Artifacts</h3>
+<h2>Related Artifacts</h2>
+
   <ul>
     {% assign alphabeticalFormats = site.formats | sort: 'title' %}
    {% for format in alphabeticalFormats %}
-     <li><h3>
-       <a href="{{ site.baseurl }}{{ format.url }}">
-       {{ format.title }}
-       </a></h3>
+     <li>
+      <h3><a href="{{ site.baseurl }}{{ format.url }}">
+       {{ format.title }}</a></h3>
+       {% if format.namevar.size > 1 %}
+       {% assign namevars = format.namevar | split: ", " %}
+         (Also known as: {% for var in format.namevar %}
+            {{ var }}
+         {% endfor %})
+       {% endif %}
      </li>
    {% endfor %}
   </ul>

--- a/formats.html
+++ b/formats.html
@@ -2,7 +2,7 @@
 layout: page
 title: Formats
 ---
-<h2>Related Artifacts</h2>
+<h2>Related Format Families</h2>
 
   <ul>
     {% assign alphabeticalFormats = site.formats | sort: 'title' %}


### PR DESCRIPTION
This shows the related names for a Format alongside the Format. This also helps if a Format (loosely defined as Format Family, really) has different names. Like D-Series is more commonly known as the formats like D1, D2, etc.

![Screenshot from 2020-07-31 15-03-11](https://user-images.githubusercontent.com/3260492/89068275-e9132300-d33e-11ea-87d7-0b81064a21de.png)
