### PR TITLE
Update betacam.md

### DIFF
--- a/_formats/betacam.md
+++ b/_formats/betacam.md
@@ -1,7 +1,7 @@
 ---
 layout: format
 title: Betacam
-namevar: [Betacam SP, Betacam Super Performance, Betacam SX, Digital Betacam, DigiBeta]
+namevar: [Betacam oxide, Betacam SP, Betacam Super Performance, Betacam SX, Digital Betacam, DigiBeta]
 categories: video analog
 tags: [Analog, Video]
 published: true


### PR DESCRIPTION
"Oxide" is a way that folks refer to the original pre-SP Betacam, when it was the same tape as Betamax, to distinguish it from the later variants.