### PR TITLE
Do not suggest to use cotton swabs

### DIFF
--- a/_artifacts/video_head_clog.md
+++ b/_artifacts/video_head_clog.md
@@ -9,7 +9,7 @@ When loose oxide builds up in the tape path, it can travel with the tape to the 
 
 ## Can it be fixed?
 
-Yes: stop playback and clean the video heads on the the player using an appropriate solvent and cotton swab. While you are at it, clean the tape path to prevent possible recontamination.
+Yes: stop playback and clean the video heads on the the player using an appropriate solvent and a piece of paper. While you are at it, clean the tape path with a cotton swab to prevent possible recontamination.
 
 There are several videos that can help you determine how to do this:
 


### PR DESCRIPTION
 for cleaning of video heads as they are easily ripped out using this method. Using a piece of paper is easier and safer.