### PR TITLE
Translate categories to JP, FR, ES

### DIFF
--- a/_artifacts/es/ac_beat.md
+++ b/_artifacts/es/ac_beat.md
@@ -2,7 +2,7 @@
 layout: post
 title: Electrical Ground Loop Interference AC Beat
 namevar: [Video hum]
-categories: video analog
+categories:  video análogo
 tags: [Analog, Audio, Video, Electrical, Cable, Device Error, Common Artifacts]
 lang: Español
 ---

--- a/_artifacts/es/analog_distortion.md
+++ b/_artifacts/es/analog_distortion.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Analog Distortion
-categories: audio analog
+categories:  audio análogo
 namevar: [Overload distortion, Harmonic distortion, Transient distortion, Nonlinear distortion, Intermodulation distortion]
 tags: [Analog, Audio, Operator Error, Levels Too Hot, Noise, Clipping]
 lang: Español

--- a/_artifacts/es/analog_noise.md
+++ b/_artifacts/es/analog_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Analog Noise
-categories: audio analog
+categories:  audio análogo
 tags: [Analog, Audio, Noise, Magnetic Tape, Cassette, Common Artifacts]
 lang: Español
 ---

--- a/_artifacts/es/analogue_slip.md
+++ b/_artifacts/es/analogue_slip.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Analogue Slipping
-categories: film analog
+categories:  film análogo
 tags: [Analog, Film]
 published: true
 lang: Español

--- a/_artifacts/es/audio_dropout.md
+++ b/_artifacts/es/audio_dropout.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Audio Dropout
-categories: audio analog digital
+categories:  audio análogo digital
 tags: [Analog, Digital, Audio, Magnetic Tape, Cleaning]
 lang: Español
 ---

--- a/_artifacts/es/audio_overwrite.md
+++ b/_artifacts/es/audio_overwrite.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Audio Overwrite
-categories: audio analog digital
+categories:  audio análogo digital
 tags: [Audio, Analog, Digital]
 lang: Español
 ---

--- a/_artifacts/es/audio_phase_error.md
+++ b/_artifacts/es/audio_phase_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Audio Phase Error
-categories: audio analog
+categories:  audio análogo
 tags: [Analog, Audio, Phase, Mono, Stereo]
 lang: Español
 ---

--- a/_artifacts/es/audio_scrape_flutter.md
+++ b/_artifacts/es/audio_scrape_flutter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Audio Scrape Flutter
-categories: audio analog
+categories:  audio análogo
 tags: [Analog, Audio, flutter, sticky, deterioration, lubrication]
 lang: Español
 ---

--- a/_artifacts/es/bad_audio_splice.md
+++ b/_artifacts/es/bad_audio_splice.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Bad Audio Splice
-categories: audio analog
+categories:  audio análogo
 tags: [Analog, Audio, Magnetic Tape, Cleaning]
 lang: Español
 ---

--- a/_artifacts/es/bearding.md
+++ b/_artifacts/es/bearding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Bearding
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Tape Error]
 formats: [VHS, 1/2" Open Reel]
 published: true

--- a/_artifacts/es/black_frames.md
+++ b/_artifacts/es/black_frames.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Black Frames
-categories: film analog
+categories:  film análogo
 tags: [Analog, Film]
 formats: [Film]
 published: true

--- a/_artifacts/es/carrier_leak.md
+++ b/_artifacts/es/carrier_leak.md
@@ -2,7 +2,7 @@
 layout: post
 title: Carrier Leak
 namevar: [Faulty carrier balance, Asymmetric carrier, Residual carrier]
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Device Error]
 lang: Español
 ---

--- a/_artifacts/es/chrominance_noise.md
+++ b/_artifacts/es/chrominance_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Chrominance Noise
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Chrominance, Noise, Common Artifacts]
 lang: Español
 ---

--- a/_artifacts/es/clicks_and_pops.md
+++ b/_artifacts/es/clicks_and_pops.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Click and Pops
-categories: audio analog
+categories:  audio análogo
 tags: [Analog, Audio, Disc Playback, Cleaning, Common Artifacts]
 lang: Español
 ---

--- a/_artifacts/es/colour_shift.md
+++ b/_artifacts/es/colour_shift.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Colour Shift
-categories: film analog
+categories:  film análogo
 namevar: [Dye fade, Magenta]
 tags: [Analog, Film, Color]
 formats: [Film]

--- a/_artifacts/es/crash_record.md
+++ b/_artifacts/es/crash_record.md
@@ -2,7 +2,7 @@
 layout: post
 title: Crash Record
 namevar: [Crash edit, Color smearing after an editing cut]
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Production Error, Color smearing, Editing cut]
 formats: [DV]
 lang: Español

--- a/_artifacts/es/crizzling.md
+++ b/_artifacts/es/crizzling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Crizzling
-categories: film analog
+categories:  film análogo
 namevar: [Crazing]
 tags: [Analog, Film]
 formats: [Film]

--- a/_artifacts/es/cross_talk_between_spiral_grooves.md
+++ b/_artifacts/es/cross_talk_between_spiral_grooves.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Cross-talk Between Spiral Grooves
-categories: audio analog
+categories:  audio análogo
 tags: [Audio, Disc Playback, Pre-echo, Analog]
 lang: Español
 ---

--- a/_artifacts/es/crushed_setup.md
+++ b/_artifacts/es/crushed_setup.md
@@ -2,7 +2,7 @@
 layout: post
 title: Crushed Setup
 namevar: [Low black level]
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Black Levels, Operator Error, Common Artifacts]
 lang: Español
 ---

--- a/_artifacts/es/digital_audio_dropout.md
+++ b/_artifacts/es/digital_audio_dropout.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Digital Audio Dropout
-categories: analog audio digital
+categories: análogo audio digital
 tags: [Audio, Digital, Dropout, Magnetic Tape, Playback Adjustment]
 formats: [DAT]
 lang: Español

--- a/_artifacts/es/digital_clipping.md
+++ b/_artifacts/es/digital_clipping.md
@@ -2,7 +2,7 @@
 layout: post
 title: Digital Clipping
 namevar: [Digital distortion]
-categories: analog audio digital
+categories: análogo audio digital
 tags: [Digital, Audio, Noise, Overs, Common Artifacts]
 lang: Español
 ---

--- a/_artifacts/es/dihedral_maladjustment.md
+++ b/_artifacts/es/dihedral_maladjustment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Dihedral Maladjustment
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Device Error, Tape Error]
 lang: Español
 ---

--- a/_artifacts/es/dirt.md
+++ b/_artifacts/es/dirt.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Dirt
-categories: film analog
+categories:  film análogo
 tags: [Analog, Film]
 formats: [Film]
 lang: Español

--- a/_artifacts/es/dirty_head_drum.md
+++ b/_artifacts/es/dirty_head_drum.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Dirty Head Drum
-categories: video analog
+categories:  video análogo
 namevar: [Occlusion]
 tags: [Analog, Video, Head Clog, Dirt, U-matic]
 formats: [U-matic]

--- a/_artifacts/es/dot_crawl.md
+++ b/_artifacts/es/dot_crawl.md
@@ -2,7 +2,7 @@
 layout: post
 title: Dot Crawl
 namevar: [Chroma crawl]
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Dot Crawl]
 lang: Español
 ---

--- a/_artifacts/es/duplicated_frames.md
+++ b/_artifacts/es/duplicated_frames.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Duplicated Frames
-categories: film analog
+categories:  film análogo
 tags: [Analog, Film]
 formats: [Film]
 lang: Español

--- a/_artifacts/es/electromagnetic_interference.md
+++ b/_artifacts/es/electromagnetic_interference.md
@@ -2,7 +2,7 @@
 layout: post
 title: Electromagnetic Interference
 namevar: [RF Interference]
-categories: audio analog
+categories:  audio análogo
 tags: [Analog, Audio, Interference, Electrical, Cable, Common Artifacts]
 lang: Español
 ---

--- a/_artifacts/es/fluorescent_strobing.md
+++ b/_artifacts/es/fluorescent_strobing.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Fluorescent Strobing
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Flicker, Strobing, Production Error]
 lang: Español
 ---

--- a/_artifacts/es/ghost.md
+++ b/_artifacts/es/ghost.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Ghost
-categories: video analog
+categories:  video análogo
 namevar: [Echo, Print Through]
 tags: [Video, Ghosting, Common Artifacts]
 lang: Español

--- a/_artifacts/es/head_equalization_error.md
+++ b/_artifacts/es/head_equalization_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Head Equalization Error
-categories: video analog
+categories:  video análogo
 tags: [Video, Analog, Chrominance, Hue, Banding, 2-inch Quad, Open Reel Tape, Device Error]
 formats: [2" Quad]
 lang: Español

--- a/_artifacts/es/head_switching_noise.md
+++ b/_artifacts/es/head_switching_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Head Switching Noise
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Noise, Device Error, Tape Error, Servo]
 formats: [VHS]
 lang: Español

--- a/_artifacts/es/herringbone.md
+++ b/_artifacts/es/herringbone.md
@@ -2,7 +2,7 @@
 layout: post
 title: Electrical Ground Loop Interference Herringbone
 namevar: [Video Hum]
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Electrical, RF, Cable, Device Error]
 lang: Español
 ---

--- a/_artifacts/es/high_video_level.md
+++ b/_artifacts/es/high_video_level.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: High Video Level
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Operator Error, Tape Error, Time Base Corrector, Levels Too Hot, Clipping]
 lang: Español
 ---

--- a/_artifacts/es/horizontal_pixel_misalignment.md
+++ b/_artifacts/es/horizontal_pixel_misalignment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Horizontal Pixel Misalignment
-categories: film analog
+categories:  film análogo
 tags: [Analog, Film]
 lang: Español
 ---

--- a/_artifacts/es/hum_and_buzz.md
+++ b/_artifacts/es/hum_and_buzz.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Hum and Buzz
-categories: video audio analog digital
+categories: video audio análogo digital
 tags: [Analog, Digital, Audio, Video, Balanced Cables, Power Supply, Cable, Common Artifacts]
 lang: Español
 ---

--- a/_artifacts/es/image_lag.md
+++ b/_artifacts/es/image_lag.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Image Lag
-categories: video analog
+categories:  video análogo
 namevar: [Ghosting, Smearing, Burn-in, Comet Tails, Luma Trails, Luminance Blooming]
 tags: [Ghosting, Smearing, Comet Tails, Tape Error, Analog, Video, Luminance Blooming]
 lang: Español

--- a/_artifacts/es/incompatibility_between_television_standards.md
+++ b/_artifacts/es/incompatibility_between_television_standards.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Incompatibility Between Television Standards
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Operator Error, Long Play, Extended Play]
 lang: Español
 ---

--- a/_artifacts/es/incorrect_speed.md
+++ b/_artifacts/es/incorrect_speed.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Incorrect Speed
-categories: video analog
+categories:  video análogo
 tags: [Audio, Analog, Deck Failure, Operator Error, Pitch, Speed Fluctuation]
 lang: Español
 ---

--- a/_artifacts/es/lengthwise_tape_expansion_or_shrinkage.md
+++ b/_artifacts/es/lengthwise_tape_expansion_or_shrinkage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Lengthwise Tape Expansion or Shrinkage
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Tape Error]
 lang: Español
 ---

--- a/_artifacts/es/level_clamping.md
+++ b/_artifacts/es/level_clamping.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Level Clamping
-categories: video analog
+categories:  video análogo
 namevar: [clipping, legalizing]
 tags: [Video, Transfer Artifact, Station Qualification, Digitization, Levels, Waveform]
 lang: Español

--- a/_artifacts/es/long_play.md
+++ b/_artifacts/es/long_play.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Long Play
-categories: video analog
+categories:  video análogo
 tags: [Video, Analog, LP, Long Play, Operator Error]
 formats: [VHS, Betamax, DV]
 lang: Español

--- a/_artifacts/es/loss_of_color_lock.md
+++ b/_artifacts/es/loss_of_color_lock.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Loss of Color Lock
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Color, PAL, Color lock, Operator Error, Device Error]
 formats: [U-matic]
 lang: Español

--- a/_artifacts/es/low_rf.md
+++ b/_artifacts/es/low_rf.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Low RF
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, RF, Cleaning]
 lang: Español
 ---

--- a/_artifacts/es/luminance_noise.md
+++ b/_artifacts/es/luminance_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Luminance Noise
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Luminance, Noise, Cable, Cleaning]
 lang: Español
 ---

--- a/_artifacts/es/missing_frames.md
+++ b/_artifacts/es/missing_frames.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Missing Frames
-categories: film analog
+categories:  film análogo
 tags: [Analog, Film]
 lang: Español
 ---

--- a/_artifacts/es/moire_effect.md
+++ b/_artifacts/es/moire_effect.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Moiré Effect
-categories: video analog
+categories:  video análogo
 tags: [Interference, Video, Analog]
 lang: Español
 ---

--- a/_artifacts/es/muffled_sound.md
+++ b/_artifacts/es/muffled_sound.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Muffled Sound
-categories: audio analog
+categories:  audio análogo
 namevar: [Azimuth Error]
 tags: [Audio, Analog, Azimuth, Error, Frequency Loss, Playback Adjustment, Media Failure, Media Damage, Oxide Out, Common Artifacts]
 lang: Español

--- a/_artifacts/es/noise_reduction.md
+++ b/_artifacts/es/noise_reduction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Noise Reduction
-categories: audio analog
+categories:  audio análogo
 namevar: [Dolby, dbx, Compander]
 tags: [Analog, Audio, Cassette, Noise, Open Reel Tape]
 lang: Español

--- a/_artifacts/es/oversaturation.md
+++ b/_artifacts/es/oversaturation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Oversaturation
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Cable, Chrominance, Color, Hue, Operator Error, Tape Error, Time Base Corrector, Common Artifacts]
 lang: Español
 ---

--- a/_artifacts/es/phantom_frames.md
+++ b/_artifacts/es/phantom_frames.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Phantom Frames
-categories: film analog
+categories:  film análogo
 tags: [Analog, Film]
 formats: [Film]
 lang: Español

--- a/_artifacts/es/pilot_tone.md
+++ b/_artifacts/es/pilot_tone.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Pilot Tone
-categories: audio video film analog
+categories: audio video film análogo
 namevar: [Double System Sound]
 tags: [Analog, Audio, Video, Film, Open Reel Tape, Hum, Synchronization]
 lang: Español

--- a/_artifacts/es/poor_yc_decoding.md
+++ b/_artifacts/es/poor_yc_decoding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Poor Y/C Decoding (S-Video crosstalk)
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Cable, Production Error]
 lang: Español
 ---

--- a/_artifacts/es/print-through.md
+++ b/_artifacts/es/print-through.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Print-through
-categories: audio analog
+categories:  audio análogo
 namevar: [Interlayer Transfer]
 tags: [Analog, Audio, Pre-echo, Post-echo, Rewinding, Magnetostrictive Action]
 lang: Español

--- a/_artifacts/es/quadrants_misalignment.md
+++ b/_artifacts/es/quadrants_misalignment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Quadrants Misalignment
-categories: film analog
+categories:  film análogo
 tags: [Analog, Film]
 formats: [Film]
 lang: Español

--- a/_artifacts/es/ringing.md
+++ b/_artifacts/es/ringing.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Ringing
-categories: video analog
+categories:  video análogo
 namevar: [Overshoot]
 tags: [Analog, Video, Cable, Time Base Corrector]
 formats: [U-matic]

--- a/_artifacts/es/scratches.md
+++ b/_artifacts/es/scratches.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Scratches
-categories: film analog
+categories:  film análogo
 tags: [Analog, Film]
 formats: [Film]
 lang: Español

--- a/_artifacts/es/scratches_and_tape_wear.md
+++ b/_artifacts/es/scratches_and_tape_wear.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Damage, Scratches and Tape Wear
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Audio, Abrasion, Gouging, Media Damage, Tape Error, Common Artifacts]
 formats: [Betamax, U-matic, VHS]
 lang: Español

--- a/_artifacts/es/skew_error.md
+++ b/_artifacts/es/skew_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Skew Error
-categories: video analog
+categories:  video análogo
 namevar: [Flagging]
 tags: [Analog, Video, Skew, Error, Time Base Corrector, Expansion, Shrinkage, Media Damage, Device Error, Tape Error, Common Artifacts]
 formats: [U-matic]

--- a/_artifacts/es/soft_binder_syndrome.md
+++ b/_artifacts/es/soft_binder_syndrome.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Soft Binder Syndrome
-categories: audio analog
+categories:  audio análogo
 namevar: [Hydrolysis, Sticky Shed Syndrome, Loss of Lubricant]
 tags: [Analog, Audio, Open Reel Tape, Media Failure, Frequency Loss, Baking, Common Artifacts]
 lang: Español

--- a/_artifacts/es/sparkle.md
+++ b/_artifacts/es/sparkle.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Sparkle
-categories: film analog
+categories:  film análogo
 tags: [Analog, Film]
 formats: [Film]
 lang: Español

--- a/_artifacts/es/stiction.md
+++ b/_artifacts/es/stiction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Stiction
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Media Failure, Cleaning, Tape Error]
 lang: Español
 ---

--- a/_artifacts/es/subcarrier_phase_error.md
+++ b/_artifacts/es/subcarrier_phase_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Subcarrier Phase Error
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Phase, Hue, Operator Error, Device Error, Common Artifacts]
 lang: Español
 ---

--- a/_artifacts/es/sync_loss.md
+++ b/_artifacts/es/sync_loss.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Sync Loss
-categories: video analog
+categories:  video análogo
 namevar: [Roll]
 tags: [Analog, Video, Synchronization]
 lang: Español

--- a/_artifacts/es/tape_deformation.md
+++ b/_artifacts/es/tape_deformation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Tape Deformation
-categories: video audio analog
+categories: video audio análogo
 tags: [Analog, Video, Audio, Deformation, Edge curl, Curvature error, Step pack, Popped strand, Flange pack, Windowing, Spoking, Media Damage]
 lang: Español
 ---

--- a/_artifacts/es/tbc_processing_artifact.md
+++ b/_artifacts/es/tbc_processing_artifact.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: TBC Processing Artifact
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Time Base Corrector, Processing Artifact]
 lang: Español
 ---

--- a/_artifacts/es/time_base_error.md
+++ b/_artifacts/es/time_base_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Time Base Error
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Time Base Corrector, Common Artifacts]
 lang: Español
 ---

--- a/_artifacts/es/tracking_error.md
+++ b/_artifacts/es/tracking_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Tracking Error
-categories: video analog
+categories:  video análogo
 namevar: [Mistracking]
 tags: [Analog, Video, Tracking Error, Common Artifacts]
 formats: [Betamax, VHS]

--- a/_artifacts/es/undersaturation.md
+++ b/_artifacts/es/undersaturation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Undersaturation
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Undersaturation, Chrominance, Common Artifacts]
 formats: [VHS, U-matic]
 lang: Español

--- a/_artifacts/es/vacuum_guide_adjustment_error.md
+++ b/_artifacts/es/vacuum_guide_adjustment_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vacuum Guide Adjustment Error
-categories: video analog
+categories:  video análogo
 tags: [Video, Analog, 2-inch Quad, Time Base Corrector, Playback Adjustment, Open Reel Tape]
 formats: [2" Quad]
 lang: Español

--- a/_artifacts/es/venetian-blind_effect.md
+++ b/_artifacts/es/venetian-blind_effect.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Venetian-blind Effect
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, PAL, Time Base Corrector, Color]
 lang: Español
 ---

--- a/_artifacts/es/vertical_pixel_misalignment.md
+++ b/_artifacts/es/vertical_pixel_misalignment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vertical Pixel Misalignment
-categories: film analog
+categories:  film análogo
 tags: [Analog, Film]
 lang: Español
 ---

--- a/_artifacts/es/video_dropout.md
+++ b/_artifacts/es/video_dropout.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Video Dropout
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Dropout, Common Artifacts]
 lang: Español
 ---

--- a/_artifacts/es/video_head_clog.md
+++ b/_artifacts/es/video_head_clog.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Video Head Clog
-categories: video analog
+categories:  video análogo
 tags: [Video, Analog, Media Failure, Cleaning, Head Clog, Common Artifacts]
 formats: [VHS, U-matic]
 lang: Español

--- a/_artifacts/es/video_jitter.md
+++ b/_artifacts/es/video_jitter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Video Jitter
-categories: video analog
+categories:  video análogo
 tags: [Video]
 lang: Español
 ---

--- a/_artifacts/es/video_overwrite.md
+++ b/_artifacts/es/video_overwrite.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Video Overwrite
-categories: video analog digital
+categories:  video análogo digital
 tags: [Video]
 lang: Español
 ---

--- a/_artifacts/es/visible_frame_line.md
+++ b/_artifacts/es/visible_frame_line.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Visible Frame Line
-categories: film analog
+categories:  film análogo
 tags: [Film]
 formats: [Film]
 lang: Español

--- a/_artifacts/es/white_balance_error.md
+++ b/_artifacts/es/white_balance_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: White Balance Error
-categories: video analog digital
+categories:  video análogo digital
 tags: [Video, Analog, Digital]
 lang: Español
 ---

--- a/_artifacts/es/wow_and_flutter.md
+++ b/_artifacts/es/wow_and_flutter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Wow and Flutter
-categories: audio analog
+categories:  audio análogo
 namevar: [Speed Fluctuation]
 tags: [Audio, Analog, Deck Failure, Speed Fluctuation, Pitch, Dying Batteries, Warble, Common Artifacts]
 lang: Español

--- a/_artifacts/es/yc_delay_error.md
+++ b/_artifacts/es/yc_delay_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Y/C Delay Error
-categories: video analog
+categories:  video análogo
 tags: [Analog, Video, Y/C Delay Error]
 lang: Español
 ---

--- a/_artifacts/fr/ac_beat.md
+++ b/_artifacts/fr/ac_beat.md
@@ -2,7 +2,7 @@
 layout: post
 title: Electrical Ground Loop Interference AC Beat
 namevar: [Video hum]
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Audio, Video, Electrical, Cable, Device Error, Common Artifacts]
 lang: Français
 ---

--- a/_artifacts/fr/analog_distortion.md
+++ b/_artifacts/fr/analog_distortion.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Analog Distortion
-categories: audio analog
+categories: audio analogique
 namevar: [Overload distortion, Harmonic distortion, Transient distortion, Nonlinear distortion, Intermodulation distortion]
 tags: [Analog, Audio, Operator Error, Levels Too Hot, Noise, Clipping]
 lang: Français

--- a/_artifacts/fr/analog_noise.md
+++ b/_artifacts/fr/analog_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Analog Noise
-categories: audio analog
+categories: audio analogique
 tags: [Analog, Audio, Noise, Magnetic Tape, Cassette, Common Artifacts]
 lang: Français
 ---

--- a/_artifacts/fr/analogue_slip.md
+++ b/_artifacts/fr/analogue_slip.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Analogue Slipping
-categories: film analog
+categories: film analogique
 tags: [Analog, Film]
 published: true
 lang: Français

--- a/_artifacts/fr/audio_dropout.md
+++ b/_artifacts/fr/audio_dropout.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Audio Dropout
-categories: audio analog digital
+categories: audio analogique digital
 tags: [Analog, Digital, Audio, Magnetic Tape, Cleaning]
 lang: Français
 ---

--- a/_artifacts/fr/audio_overwrite.md
+++ b/_artifacts/fr/audio_overwrite.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Audio Overwrite
-categories: audio analog digital
+categories: audio analogique digital
 tags: [Audio, Analog, Digital]
 lang: Français
 ---

--- a/_artifacts/fr/audio_phase_error.md
+++ b/_artifacts/fr/audio_phase_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Audio Phase Error
-categories: audio analog
+categories: audio analogique
 tags: [Analog, Audio, Phase, Mono, Stereo]
 lang: Français
 ---

--- a/_artifacts/fr/audio_scrape_flutter.md
+++ b/_artifacts/fr/audio_scrape_flutter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Audio Scrape Flutter
-categories: audio analog
+categories: audio analogique
 tags: [Analog, Audio, flutter, sticky, deterioration, lubrication]
 lang: Français
 ---

--- a/_artifacts/fr/bad_audio_splice.md
+++ b/_artifacts/fr/bad_audio_splice.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Bad Audio Splice
-categories: audio analog
+categories: audio analogique
 tags: [Analog, Audio, Magnetic Tape, Cleaning]
 lang: Français
 ---

--- a/_artifacts/fr/bearding.md
+++ b/_artifacts/fr/bearding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Bearding
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Tape Error]
 formats: [VHS, 1/2" Open Reel]
 published: true

--- a/_artifacts/fr/black_frames.md
+++ b/_artifacts/fr/black_frames.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Black Frames
-categories: film analog
+categories: film analogique
 tags: [Analog, Film]
 formats: [Film]
 published: true

--- a/_artifacts/fr/block_noise.md
+++ b/_artifacts/fr/block_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Block Noise
-categories: digital video
+categories: digital vidéo
 tags: [Digital, Video, Noise]
 lang: Français
 ---

--- a/_artifacts/fr/carrier_leak.md
+++ b/_artifacts/fr/carrier_leak.md
@@ -2,7 +2,7 @@
 layout: post
 title: Carrier Leak
 namevar: [Faulty carrier balance, Asymmetric carrier, Residual carrier]
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Device Error]
 lang: Français
 ---

--- a/_artifacts/fr/chrominance_noise.md
+++ b/_artifacts/fr/chrominance_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Chrominance Noise
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Chrominance, Noise, Common Artifacts]
 lang: Français
 ---

--- a/_artifacts/fr/clicks_and_pops.md
+++ b/_artifacts/fr/clicks_and_pops.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Click and Pops
-categories: audio analog
+categories: audio analogique
 tags: [Analog, Audio, Disc Playback, Cleaning, Common Artifacts]
 lang: Français
 ---

--- a/_artifacts/fr/colour_shift.md
+++ b/_artifacts/fr/colour_shift.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Colour Shift
-categories: film analog
+categories: film analogique
 namevar: [Dye fade, Magenta]
 tags: [Analog, Film, Color]
 formats: [Film]

--- a/_artifacts/fr/crash_record.md
+++ b/_artifacts/fr/crash_record.md
@@ -2,7 +2,7 @@
 layout: post
 title: Crash Record
 namevar: [Crash edit, Color smearing after an editing cut]
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Production Error, Color smearing, Editing cut]
 formats: [DV]
 lang: Français

--- a/_artifacts/fr/crizzling.md
+++ b/_artifacts/fr/crizzling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Crizzling
-categories: film analog
+categories: film analogique
 namevar: [Crazing]
 tags: [Analog, Film]
 formats: [Film]

--- a/_artifacts/fr/cross_talk_between_spiral_grooves.md
+++ b/_artifacts/fr/cross_talk_between_spiral_grooves.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Cross-talk Between Spiral Grooves
-categories: audio analog
+categories: audio analogique
 tags: [Audio, Disc Playback, Pre-echo, Analog]
 lang: Français
 ---

--- a/_artifacts/fr/crushed_setup.md
+++ b/_artifacts/fr/crushed_setup.md
@@ -2,7 +2,7 @@
 layout: post
 title: Crushed Setup
 namevar: [Low black level]
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Black Levels, Operator Error, Common Artifacts]
 lang: Français
 ---

--- a/_artifacts/fr/digital_audio_dropout.md
+++ b/_artifacts/fr/digital_audio_dropout.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Digital Audio Dropout
-categories: analog audio digital
+categories: analogique audio digital
 tags: [Audio, Digital, Dropout, Magnetic Tape, Playback Adjustment]
 formats: [DAT]
 lang: Français

--- a/_artifacts/fr/digital_clipping.md
+++ b/_artifacts/fr/digital_clipping.md
@@ -2,7 +2,7 @@
 layout: post
 title: Digital Clipping
 namevar: [Digital distortion]
-categories: analog audio digital
+categories: analogique audio digital
 tags: [Digital, Audio, Noise, Overs, Common Artifacts]
 lang: Français
 ---

--- a/_artifacts/fr/dihedral_maladjustment.md
+++ b/_artifacts/fr/dihedral_maladjustment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Dihedral Maladjustment
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Device Error, Tape Error]
 lang: Français
 ---

--- a/_artifacts/fr/dirt.md
+++ b/_artifacts/fr/dirt.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Dirt
-categories: film analog
+categories: film analogique
 tags: [Analog, Film]
 formats: [Film]
 lang: Français

--- a/_artifacts/fr/dirty_head_drum.md
+++ b/_artifacts/fr/dirty_head_drum.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Dirty Head Drum
-categories: video analog
+categories: vidéo analogique
 namevar: [Occlusion]
 tags: [Analog, Video, Head Clog, Dirt, U-matic]
 formats: [U-matic]

--- a/_artifacts/fr/dot_crawl.md
+++ b/_artifacts/fr/dot_crawl.md
@@ -2,7 +2,7 @@
 layout: post
 title: Dot Crawl
 namevar: [Chroma crawl]
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Dot Crawl]
 lang: Français
 ---

--- a/_artifacts/fr/duplicated_frames.md
+++ b/_artifacts/fr/duplicated_frames.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Duplicated Frames
-categories: film analog
+categories: film analogique
 tags: [Analog, Film]
 formats: [Film]
 lang: Français

--- a/_artifacts/fr/dv_dropout.md
+++ b/_artifacts/fr/dv_dropout.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: DV Dropout
-categories: video digital
+categories: vidéo digital
 tags: [Digital, Video, DV, Dropout, Cleaning]
 formats: [DV]
 lang: Français

--- a/_artifacts/fr/dv_quilting.md
+++ b/_artifacts/fr/dv_quilting.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: DV Quilting
-categories: video digital
+categories: vidéo digital
 tags: [Digital, Video, Quilting, Discrete Cosine Transform, Error, DV]
 formats: [DV]
 lang: Français

--- a/_artifacts/fr/dv_record_head_clog.md
+++ b/_artifacts/fr/dv_record_head_clog.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: DV Record Head Clog
-categories: video digital
+categories: vidéo digital
 tags: [DV, Dropout, Head Clog]
 formats: [DV]
 lang: Français

--- a/_artifacts/fr/electromagnetic_interference.md
+++ b/_artifacts/fr/electromagnetic_interference.md
@@ -2,7 +2,7 @@
 layout: post
 title: Electromagnetic Interference
 namevar: [RF Interference]
-categories: audio analog
+categories: audio analogique
 tags: [Analog, Audio, Interference, Electrical, Cable, Common Artifacts]
 lang: Français
 ---

--- a/_artifacts/fr/fluorescent_strobing.md
+++ b/_artifacts/fr/fluorescent_strobing.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Fluorescent Strobing
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Flicker, Strobing, Production Error]
 lang: Français
 ---

--- a/_artifacts/fr/ghost.md
+++ b/_artifacts/fr/ghost.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Ghost
-categories: video analog
+categories: vidéo analogique
 namevar: [Echo, Print Through]
 tags: [Video, Ghosting, Common Artifacts]
 lang: Français

--- a/_artifacts/fr/head_clog_banding.md
+++ b/_artifacts/fr/head_clog_banding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Head Clog Banding
-categories: video digital
+categories: vidéo digital
 tags: [Digital, Video, Head Clog, Banding, DV]
 formats: [DV]
 lang: Français

--- a/_artifacts/fr/head_equalization_error.md
+++ b/_artifacts/fr/head_equalization_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Head Equalization Error
-categories: video analog
+categories: vidéo analogique
 tags: [Video, Analog, Chrominance, Hue, Banding, 2-inch Quad, Open Reel Tape, Device Error]
 formats: [2" Quad]
 lang: Français

--- a/_artifacts/fr/head_switching_noise.md
+++ b/_artifacts/fr/head_switching_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Head Switching Noise
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Noise, Device Error, Tape Error, Servo]
 formats: [VHS]
 lang: Français

--- a/_artifacts/fr/herringbone.md
+++ b/_artifacts/fr/herringbone.md
@@ -2,7 +2,7 @@
 layout: post
 title: Electrical Ground Loop Interference Herringbone
 namevar: [Video Hum]
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Electrical, RF, Cable, Device Error]
 lang: Français
 ---

--- a/_artifacts/fr/high_video_level.md
+++ b/_artifacts/fr/high_video_level.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: High Video Level
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Operator Error, Tape Error, Time Base Corrector, Levels Too Hot, Clipping]
 lang: Français
 ---

--- a/_artifacts/fr/horizontal_pixel_misalignment.md
+++ b/_artifacts/fr/horizontal_pixel_misalignment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Horizontal Pixel Misalignment
-categories: film analog
+categories: film analogique
 tags: [Analog, Film]
 lang: Français
 ---

--- a/_artifacts/fr/hum_and_buzz.md
+++ b/_artifacts/fr/hum_and_buzz.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Hum and Buzz
-categories: video audio analog digital
+categories: vidéo audio analogique digital
 tags: [Analog, Digital, Audio, Video, Balanced Cables, Power Supply, Cable, Common Artifacts]
 lang: Français
 ---

--- a/_artifacts/fr/image_lag.md
+++ b/_artifacts/fr/image_lag.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Image Lag
-categories: video analog
+categories: vidéo analogique
 namevar: [Ghosting, Smearing, Burn-in, Comet Tails, Luma Trails, Luminance Blooming]
 tags: [Ghosting, Smearing, Comet Tails, Tape Error, Analog, Video, Luminance Blooming]
 lang: Français

--- a/_artifacts/fr/incompatibility_between_television_standards.md
+++ b/_artifacts/fr/incompatibility_between_television_standards.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Incompatibility Between Television Standards
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Operator Error, Long Play, Extended Play]
 lang: Français
 ---

--- a/_artifacts/fr/incorrect_speed.md
+++ b/_artifacts/fr/incorrect_speed.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Incorrect Speed
-categories: video analog
+categories: vidéo analogique
 tags: [Audio, Analog, Deck Failure, Operator Error, Pitch, Speed Fluctuation]
 lang: Français
 ---

--- a/_artifacts/fr/interstitial_error.md
+++ b/_artifacts/fr/interstitial_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Interstitial Error
-categories: video digital
+categories: vidéo digital
 tags: [Audio, Digital, System Failure, Dropout, Digital Clicks]
 lang: Français
 ---

--- a/_artifacts/fr/lengthwise_tape_expansion_or_shrinkage.md
+++ b/_artifacts/fr/lengthwise_tape_expansion_or_shrinkage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Lengthwise Tape Expansion or Shrinkage
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Tape Error]
 lang: Français
 ---

--- a/_artifacts/fr/level_clamping.md
+++ b/_artifacts/fr/level_clamping.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Level Clamping
-categories: video analog
+categories: vidéo analogique
 namevar: [clipping, legalizing]
 tags: [Video, Transfer Artifact, Station Qualification, Digitization, Levels, Waveform]
 lang: Français

--- a/_artifacts/fr/long_play.md
+++ b/_artifacts/fr/long_play.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Long Play
-categories: video analog
+categories: vidéo analogique
 tags: [Video, Analog, LP, Long Play, Operator Error]
 formats: [VHS, Betamax, DV]
 lang: Français

--- a/_artifacts/fr/loss_of_color_lock.md
+++ b/_artifacts/fr/loss_of_color_lock.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Loss of Color Lock
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Color, PAL, Color lock, Operator Error, Device Error]
 formats: [U-matic]
 lang: Français

--- a/_artifacts/fr/low_rf.md
+++ b/_artifacts/fr/low_rf.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Low RF
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, RF, Cleaning]
 lang: Français
 ---

--- a/_artifacts/fr/luminance_noise.md
+++ b/_artifacts/fr/luminance_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Luminance Noise
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Luminance, Noise, Cable, Cleaning]
 lang: Français
 ---

--- a/_artifacts/fr/missing_frames.md
+++ b/_artifacts/fr/missing_frames.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Missing Frames
-categories: film analog
+categories: film analogique
 tags: [Analog, Film]
 lang: Français
 ---

--- a/_artifacts/fr/moire_effect.md
+++ b/_artifacts/fr/moire_effect.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Moiré Effect
-categories: video analog
+categories: vidéo analogique
 tags: [Interference, Video, Analog]
 lang: Français
 ---

--- a/_artifacts/fr/mosquito_noise.md
+++ b/_artifacts/fr/mosquito_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Mosquito Noise
-categories: video digital
+categories: vidéo digital
 tags: [Digital, Video, Noise, MPEG, DV25, Discrete Cosine Transform]
 lang: Français
 ---

--- a/_artifacts/fr/muffled_sound.md
+++ b/_artifacts/fr/muffled_sound.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Muffled Sound
-categories: audio analog
+categories: audio analogique
 namevar: [Azimuth Error]
 tags: [Audio, Analog, Azimuth, Error, Frequency Loss, Playback Adjustment, Media Failure, Media Damage, Oxide Out, Common Artifacts]
 lang: Français

--- a/_artifacts/fr/noise_reduction.md
+++ b/_artifacts/fr/noise_reduction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Noise Reduction
-categories: audio analog
+categories: audio analogique
 namevar: [Dolby, dbx, Compander]
 tags: [Analog, Audio, Cassette, Noise, Open Reel Tape]
 lang: Français

--- a/_artifacts/fr/oversaturation.md
+++ b/_artifacts/fr/oversaturation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Oversaturation
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Cable, Chrominance, Color, Hue, Operator Error, Tape Error, Time Base Corrector, Common Artifacts]
 lang: Français
 ---

--- a/_artifacts/fr/phantom_frames.md
+++ b/_artifacts/fr/phantom_frames.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Phantom Frames
-categories: film analog
+categories: film analogique
 tags: [Analog, Film]
 formats: [Film]
 lang: Français

--- a/_artifacts/fr/pilot_tone.md
+++ b/_artifacts/fr/pilot_tone.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Pilot Tone
-categories: audio video film analog
+categories: audio vidéo film analogique
 namevar: [Double System Sound]
 tags: [Analog, Audio, Video, Film, Open Reel Tape, Hum, Synchronization]
 lang: Français

--- a/_artifacts/fr/poor_yc_decoding.md
+++ b/_artifacts/fr/poor_yc_decoding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Poor Y/C Decoding (S-Video crosstalk)
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Cable, Production Error]
 lang: Français
 ---

--- a/_artifacts/fr/print-through.md
+++ b/_artifacts/fr/print-through.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Print-through
-categories: audio analog
+categories: audio analogique
 namevar: [Interlayer Transfer]
 tags: [Analog, Audio, Pre-echo, Post-echo, Rewinding, Magnetostrictive Action]
 lang: Français

--- a/_artifacts/fr/quadrants_misalignment.md
+++ b/_artifacts/fr/quadrants_misalignment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Quadrants Misalignment
-categories: film analog
+categories: film analogique
 tags: [Analog, Film]
 formats: [Film]
 lang: Français

--- a/_artifacts/fr/ringing.md
+++ b/_artifacts/fr/ringing.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Ringing
-categories: video analog
+categories: vidéo analogique
 namevar: [Overshoot]
 tags: [Analog, Video, Cable, Time Base Corrector]
 formats: [U-matic]

--- a/_artifacts/fr/scratches.md
+++ b/_artifacts/fr/scratches.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Scratches
-categories: film analog
+categories: film analogique
 tags: [Analog, Film]
 formats: [Film]
 lang: Français

--- a/_artifacts/fr/scratches_and_tape_wear.md
+++ b/_artifacts/fr/scratches_and_tape_wear.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Damage, Scratches and Tape Wear
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Audio, Abrasion, Gouging, Media Damage, Tape Error, Common Artifacts]
 formats: [Betamax, U-matic, VHS]
 lang: Français

--- a/_artifacts/fr/sdi_spike.md
+++ b/_artifacts/fr/sdi_spike.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: SDI Spike
-categories: video digital
+categories: vidéo digital
 tags: [Video, Digital]
 lang: Français
 ---

--- a/_artifacts/fr/skew_error.md
+++ b/_artifacts/fr/skew_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Skew Error
-categories: video analog
+categories: vidéo analogique
 namevar: [Flagging]
 tags: [Analog, Video, Skew, Error, Time Base Corrector, Expansion, Shrinkage, Media Damage, Device Error, Tape Error, Common Artifacts]
 formats: [U-matic]

--- a/_artifacts/fr/smpte_time_code.md
+++ b/_artifacts/fr/smpte_time_code.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: SMPTE Time Code
-categories: audio video film
+categories: audio vidéo film
 tags: [Analog, Audio, Video, Film, Pulse, Synchronization, Open Reel Tape]
 lang: Français
 ---

--- a/_artifacts/fr/soft_binder_syndrome.md
+++ b/_artifacts/fr/soft_binder_syndrome.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Soft Binder Syndrome
-categories: audio analog
+categories: audio analogique
 namevar: [Hydrolysis, Sticky Shed Syndrome, Loss of Lubricant]
 tags: [Analog, Audio, Open Reel Tape, Media Failure, Frequency Loss, Baking, Common Artifacts]
 lang: Français

--- a/_artifacts/fr/sparkle.md
+++ b/_artifacts/fr/sparkle.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Sparkle
-categories: film analog
+categories: film analogique
 tags: [Analog, Film]
 formats: [Film]
 lang: Français

--- a/_artifacts/fr/stiction.md
+++ b/_artifacts/fr/stiction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Stiction
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Media Failure, Cleaning, Tape Error]
 lang: Français
 ---

--- a/_artifacts/fr/sub-sampling_artifact.md
+++ b/_artifacts/fr/sub-sampling_artifact.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Sub-sampling artifact
-categories: video digital
+categories: vidéo digital
 tags: [Digital, Video, DV25, Sub-sampling]
 lang: Français
 ---

--- a/_artifacts/fr/subcarrier_phase_error.md
+++ b/_artifacts/fr/subcarrier_phase_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Subcarrier Phase Error
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Phase, Hue, Operator Error, Device Error, Common Artifacts]
 lang: Français
 ---

--- a/_artifacts/fr/sync_loss.md
+++ b/_artifacts/fr/sync_loss.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Sync Loss
-categories: video analog
+categories: vidéo analogique
 namevar: [Roll]
 tags: [Analog, Video, Synchronization]
 lang: Français

--- a/_artifacts/fr/tape_deformation.md
+++ b/_artifacts/fr/tape_deformation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Tape Deformation
-categories: video audio analog
+categories: vidéo audio analogique
 tags: [Analog, Video, Audio, Deformation, Edge curl, Curvature error, Step pack, Popped strand, Flange pack, Windowing, Spoking, Media Damage]
 lang: Français
 ---

--- a/_artifacts/fr/tbc_processing_artifact.md
+++ b/_artifacts/fr/tbc_processing_artifact.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: TBC Processing Artifact
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Time Base Corrector, Processing Artifact]
 lang: Français
 ---

--- a/_artifacts/fr/time_base_error.md
+++ b/_artifacts/fr/time_base_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Time Base Error
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Time Base Corrector, Common Artifacts]
 lang: Français
 ---

--- a/_artifacts/fr/tracking_error.md
+++ b/_artifacts/fr/tracking_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Tracking Error
-categories: video analog
+categories: vidéo analogique
 namevar: [Mistracking]
 tags: [Analog, Video, Tracking Error, Common Artifacts]
 formats: [Betamax, VHS]

--- a/_artifacts/fr/undersaturation.md
+++ b/_artifacts/fr/undersaturation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Undersaturation
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Undersaturation, Chrominance, Common Artifacts]
 formats: [VHS, U-matic]
 lang: Français

--- a/_artifacts/fr/vacuum_guide_adjustment_error.md
+++ b/_artifacts/fr/vacuum_guide_adjustment_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vacuum Guide Adjustment Error
-categories: video analog
+categories: vidéo analogique
 tags: [Video, Analog, 2-inch Quad, Time Base Corrector, Playback Adjustment, Open Reel Tape]
 formats: [2" Quad]
 lang: Français

--- a/_artifacts/fr/venetian-blind_effect.md
+++ b/_artifacts/fr/venetian-blind_effect.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Venetian-blind Effect
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, PAL, Time Base Corrector, Color]
 lang: Français
 ---

--- a/_artifacts/fr/vertical_pixel_misalignment.md
+++ b/_artifacts/fr/vertical_pixel_misalignment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vertical Pixel Misalignment
-categories: film analog
+categories: film analogique
 tags: [Analog, Film]
 lang: Français
 ---

--- a/_artifacts/fr/vertical_smearing.md
+++ b/_artifacts/fr/vertical_smearing.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vertical Smearing
-categories: digital video
+categories: digital vidéo
 tags: [Digital, Video]
 lang: Français
 ---

--- a/_artifacts/fr/video_dropout.md
+++ b/_artifacts/fr/video_dropout.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Video Dropout
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Dropout, Common Artifacts]
 lang: Français
 ---

--- a/_artifacts/fr/video_head_clog.md
+++ b/_artifacts/fr/video_head_clog.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Video Head Clog
-categories: video analog
+categories: vidéo analogique
 tags: [Video, Analog, Media Failure, Cleaning, Head Clog, Common Artifacts]
 formats: [VHS, U-matic]
 lang: Français

--- a/_artifacts/fr/video_jitter.md
+++ b/_artifacts/fr/video_jitter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Video Jitter
-categories: video analog
+categories: vidéo analogique
 tags: [Video]
 lang: Français
 ---

--- a/_artifacts/fr/video_overwrite.md
+++ b/_artifacts/fr/video_overwrite.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Video Overwrite
-categories: video analog digital
+categories: vidéo analogique digital
 tags: [Video]
 lang: Français
 ---

--- a/_artifacts/fr/visible_frame_line.md
+++ b/_artifacts/fr/visible_frame_line.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Visible Frame Line
-categories: film analog
+categories: film analogique
 tags: [Film]
 formats: [Film]
 lang: Français

--- a/_artifacts/fr/white_balance_error.md
+++ b/_artifacts/fr/white_balance_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: White Balance Error
-categories: video analog digital
+categories: vidéo analogique digital
 tags: [Video, Analog, Digital]
 lang: Français
 ---

--- a/_artifacts/fr/wow_and_flutter.md
+++ b/_artifacts/fr/wow_and_flutter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Wow and Flutter
-categories: audio analog
+categories: audio analogique
 namevar: [Speed Fluctuation]
 tags: [Audio, Analog, Deck Failure, Speed Fluctuation, Pitch, Dying Batteries, Warble, Common Artifacts]
 lang: Français

--- a/_artifacts/fr/yc_delay_error.md
+++ b/_artifacts/fr/yc_delay_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Y/C Delay Error
-categories: video analog
+categories: vidéo analogique
 tags: [Analog, Video, Y/C Delay Error]
 lang: Français
 ---

--- a/_artifacts/jp/ac_beat.md
+++ b/_artifacts/jp/ac_beat.md
@@ -2,7 +2,7 @@
 layout: post
 title: Electrical Ground Loop Interference AC Beat
 namevar: [Video hum]
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Audio, Video, Electrical, Cable, Device Error, Common Artifacts]
 lang: 日本語
 ---

--- a/_artifacts/jp/analog_distortion.md
+++ b/_artifacts/jp/analog_distortion.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Analog Distortion
-categories: audio analog
+categories:  オーディオ  アナログ  
 namevar: [Overload distortion, Harmonic distortion, Transient distortion, Nonlinear distortion, Intermodulation distortion]
 tags: [Analog, Audio, Operator Error, Levels Too Hot, Noise, Clipping]
 lang: 日本語

--- a/_artifacts/jp/analog_noise.md
+++ b/_artifacts/jp/analog_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Analog Noise
-categories: audio analog
+categories:  オーディオ  アナログ  
 tags: [Analog, Audio, Noise, Magnetic Tape, Cassette, Common Artifacts]
 lang: 日本語
 ---

--- a/_artifacts/jp/analogue_slip.md
+++ b/_artifacts/jp/analogue_slip.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Analogue Slipping
-categories: film analog
+categories:  フィルム アナログ  
 tags: [Analog, Film]
 published: true
 lang: 日本語

--- a/_artifacts/jp/audio_dropout.md
+++ b/_artifacts/jp/audio_dropout.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Audio Dropout
-categories: audio analog digital
+categories:  オーディオ  アナログ  デジタル
 tags: [Analog, Digital, Audio, Magnetic Tape, Cleaning]
 lang: 日本語
 ---

--- a/_artifacts/jp/audio_overwrite.md
+++ b/_artifacts/jp/audio_overwrite.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Audio Overwrite
-categories: audio analog digital
+categories:  オーディオ  アナログ  デジタル
 tags: [Audio, Analog, Digital]
 lang: 日本語
 ---

--- a/_artifacts/jp/audio_phase_error.md
+++ b/_artifacts/jp/audio_phase_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Audio Phase Error
-categories: audio analog
+categories:  オーディオ  アナログ  
 tags: [Analog, Audio, Phase, Mono, Stereo]
 lang: 日本語
 ---

--- a/_artifacts/jp/audio_scrape_flutter.md
+++ b/_artifacts/jp/audio_scrape_flutter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Audio Scrape Flutter
-categories: audio analog
+categories:  オーディオ  アナログ  
 tags: [Analog, Audio, flutter, sticky, deterioration, lubrication]
 lang: 日本語
 ---

--- a/_artifacts/jp/bad_audio_splice.md
+++ b/_artifacts/jp/bad_audio_splice.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Bad Audio Splice
-categories: audio analog
+categories:  オーディオ  アナログ  
 tags: [Analog, Audio, Magnetic Tape, Cleaning]
 lang: 日本語
 ---

--- a/_artifacts/jp/bearding.md
+++ b/_artifacts/jp/bearding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Bearding
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Tape Error]
 formats: [VHS, 1/2" Open Reel]
 published: true

--- a/_artifacts/jp/black_frames.md
+++ b/_artifacts/jp/black_frames.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Black Frames
-categories: film analog
+categories:  フィルム アナログ  
 tags: [Analog, Film]
 formats: [Film]
 published: true

--- a/_artifacts/jp/block_noise.md
+++ b/_artifacts/jp/block_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Block Noise
-categories: digital video
+categories:  デジタル ビデオ 
 tags: [Digital, Video, Noise]
 lang: 日本語
 ---

--- a/_artifacts/jp/carrier_leak.md
+++ b/_artifacts/jp/carrier_leak.md
@@ -2,7 +2,7 @@
 layout: post
 title: Carrier Leak
 namevar: [Faulty carrier balance, Asymmetric carrier, Residual carrier]
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Device Error]
 lang: 日本語
 ---

--- a/_artifacts/jp/chrominance_noise.md
+++ b/_artifacts/jp/chrominance_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Chrominance Noise
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Chrominance, Noise, Common Artifacts]
 lang: 日本語
 ---

--- a/_artifacts/jp/clicks_and_pops.md
+++ b/_artifacts/jp/clicks_and_pops.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Click and Pops
-categories: audio analog
+categories:  オーディオ  アナログ  
 tags: [Analog, Audio, Disc Playback, Cleaning, Common Artifacts]
 lang: 日本語
 ---

--- a/_artifacts/jp/colour_shift.md
+++ b/_artifacts/jp/colour_shift.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Colour Shift
-categories: film analog
+categories:  フィルム アナログ  
 namevar: [Dye fade, Magenta]
 tags: [Analog, Film, Color]
 formats: [Film]

--- a/_artifacts/jp/crash_record.md
+++ b/_artifacts/jp/crash_record.md
@@ -2,7 +2,7 @@
 layout: post
 title: Crash Record
 namevar: [Crash edit, Color smearing after an editing cut]
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Production Error, Color smearing, Editing cut]
 formats: [DV]
 lang: 日本語

--- a/_artifacts/jp/crizzling.md
+++ b/_artifacts/jp/crizzling.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Crizzling
-categories: film analog
+categories:  フィルム アナログ  
 namevar: [Crazing]
 tags: [Analog, Film]
 formats: [Film]

--- a/_artifacts/jp/cross_talk_between_spiral_grooves.md
+++ b/_artifacts/jp/cross_talk_between_spiral_grooves.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Cross-talk Between Spiral Grooves
-categories: audio analog
+categories:  オーディオ  アナログ  
 tags: [Audio, Disc Playback, Pre-echo, Analog]
 lang: 日本語
 ---

--- a/_artifacts/jp/crushed_setup.md
+++ b/_artifacts/jp/crushed_setup.md
@@ -2,7 +2,7 @@
 layout: post
 title: Crushed Setup
 namevar: [Low black level]
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Black Levels, Operator Error, Common Artifacts]
 lang: 日本語
 ---

--- a/_artifacts/jp/digital_audio_dropout.md
+++ b/_artifacts/jp/digital_audio_dropout.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Digital Audio Dropout
-categories: analog audio digital
+categories:  アナログ オーディオ デジタル
 tags: [Audio, Digital, Dropout, Magnetic Tape, Playback Adjustment]
 formats: [DAT]
 lang: 日本語

--- a/_artifacts/jp/digital_clipping.md
+++ b/_artifacts/jp/digital_clipping.md
@@ -2,7 +2,7 @@
 layout: post
 title: Digital Clipping
 namevar: [Digital distortion]
-categories: analog audio digital
+categories:  アナログ オーディオ デジタル
 tags: [Digital, Audio, Noise, Overs, Common Artifacts]
 lang: 日本語
 ---

--- a/_artifacts/jp/dihedral_maladjustment.md
+++ b/_artifacts/jp/dihedral_maladjustment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Dihedral Maladjustment
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Device Error, Tape Error]
 lang: 日本語
 ---

--- a/_artifacts/jp/dirt.md
+++ b/_artifacts/jp/dirt.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Dirt
-categories: film analog
+categories:  フィルム アナログ  
 tags: [Analog, Film]
 formats: [Film]
 lang: 日本語

--- a/_artifacts/jp/dirty_head_drum.md
+++ b/_artifacts/jp/dirty_head_drum.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Dirty Head Drum
-categories: video analog
+categories:  ビデオ アナログ  
 namevar: [Occlusion]
 tags: [Analog, Video, Head Clog, Dirt, U-matic]
 formats: [U-matic]

--- a/_artifacts/jp/dot_crawl.md
+++ b/_artifacts/jp/dot_crawl.md
@@ -2,7 +2,7 @@
 layout: post
 title: Dot Crawl
 namevar: [Chroma crawl]
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Dot Crawl]
 lang: 日本語
 ---

--- a/_artifacts/jp/duplicated_frames.md
+++ b/_artifacts/jp/duplicated_frames.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Duplicated Frames
-categories: film analog
+categories:  フィルム アナログ  
 tags: [Analog, Film]
 formats: [Film]
 lang: 日本語

--- a/_artifacts/jp/dv_dropout.md
+++ b/_artifacts/jp/dv_dropout.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: DV Dropout
-categories: video digital
+categories:  ビデオ デジタル
 tags: [Digital, Video, DV, Dropout, Cleaning]
 formats: [DV]
 lang: 日本語

--- a/_artifacts/jp/dv_quilting.md
+++ b/_artifacts/jp/dv_quilting.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: DV Quilting
-categories: video digital
+categories:  ビデオ デジタル
 tags: [Digital, Video, Quilting, Discrete Cosine Transform, Error, DV]
 formats: [DV]
 lang: 日本語

--- a/_artifacts/jp/dv_record_head_clog.md
+++ b/_artifacts/jp/dv_record_head_clog.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: DV Record Head Clog
-categories: video digital
+categories:  ビデオ デジタル
 tags: [DV, Dropout, Head Clog]
 formats: [DV]
 lang: 日本語

--- a/_artifacts/jp/electromagnetic_interference.md
+++ b/_artifacts/jp/electromagnetic_interference.md
@@ -2,7 +2,7 @@
 layout: post
 title: Electromagnetic Interference
 namevar: [RF Interference]
-categories: audio analog
+categories:  オーディオ  アナログ  
 tags: [Analog, Audio, Interference, Electrical, Cable, Common Artifacts]
 lang: 日本語
 ---

--- a/_artifacts/jp/fluorescent_strobing.md
+++ b/_artifacts/jp/fluorescent_strobing.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Fluorescent Strobing
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Flicker, Strobing, Production Error]
 lang: 日本語
 ---

--- a/_artifacts/jp/ghost.md
+++ b/_artifacts/jp/ghost.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Ghost
-categories: video analog
+categories:  ビデオ アナログ  
 namevar: [Echo, Print Through]
 tags: [Video, Ghosting, Common Artifacts]
 lang: 日本語

--- a/_artifacts/jp/head_clog_banding.md
+++ b/_artifacts/jp/head_clog_banding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Head Clog Banding
-categories: video digital
+categories:  ビデオ デジタル
 tags: [Digital, Video, Head Clog, Banding, DV]
 formats: [DV]
 lang: 日本語

--- a/_artifacts/jp/head_equalization_error.md
+++ b/_artifacts/jp/head_equalization_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Head Equalization Error
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Video, Analog, Chrominance, Hue, Banding, 2-inch Quad, Open Reel Tape, Device Error]
 formats: [2" Quad]
 lang: 日本語

--- a/_artifacts/jp/head_switching_noise.md
+++ b/_artifacts/jp/head_switching_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Head Switching Noise
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Noise, Device Error, Tape Error, Servo]
 formats: [VHS]
 lang: 日本語

--- a/_artifacts/jp/herringbone.md
+++ b/_artifacts/jp/herringbone.md
@@ -2,7 +2,7 @@
 layout: post
 title: Electrical Ground Loop Interference Herringbone
 namevar: [Video Hum]
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Electrical, RF, Cable, Device Error]
 lang: 日本語
 ---

--- a/_artifacts/jp/high_video_level.md
+++ b/_artifacts/jp/high_video_level.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: High Video Level
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Operator Error, Tape Error, Time Base Corrector, Levels Too Hot, Clipping]
 lang: 日本語
 ---

--- a/_artifacts/jp/horizontal_pixel_misalignment.md
+++ b/_artifacts/jp/horizontal_pixel_misalignment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Horizontal Pixel Misalignment
-categories: film analog
+categories:  フィルム アナログ  
 tags: [Analog, Film]
 lang: 日本語
 ---

--- a/_artifacts/jp/hum_and_buzz.md
+++ b/_artifacts/jp/hum_and_buzz.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Hum and Buzz
-categories: video audio analog digital
+categories:  ビデオ オーディオ アナログ デジタル
 tags: [Analog, Digital, Audio, Video, Balanced Cables, Power Supply, Cable, Common Artifacts]
 lang: 日本語
 ---

--- a/_artifacts/jp/image_lag.md
+++ b/_artifacts/jp/image_lag.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Image Lag
-categories: video analog
+categories:  ビデオ アナログ  
 namevar: [Ghosting, Smearing, Burn-in, Comet Tails, Luma Trails, Luminance Blooming]
 tags: [Ghosting, Smearing, Comet Tails, Tape Error, Analog, Video, Luminance Blooming]
 lang: 日本語

--- a/_artifacts/jp/incompatibility_between_television_standards.md
+++ b/_artifacts/jp/incompatibility_between_television_standards.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Incompatibility Between Television Standards
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Operator Error, Long Play, Extended Play]
 lang: 日本語
 ---

--- a/_artifacts/jp/incorrect_speed.md
+++ b/_artifacts/jp/incorrect_speed.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Incorrect Speed
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Audio, Analog, Deck Failure, Operator Error, Pitch, Speed Fluctuation]
 lang: 日本語
 ---

--- a/_artifacts/jp/interstitial_error.md
+++ b/_artifacts/jp/interstitial_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Interstitial Error
-categories: video digital
+categories:  ビデオ デジタル
 tags: [Audio, Digital, System Failure, Dropout, Digital Clicks]
 lang: 日本語
 ---

--- a/_artifacts/jp/jitter.md
+++ b/_artifacts/jp/jitter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Audio Jitter
-categories: audio
+categories: オーディオ
 tags: [Analog, Error, Noise, Clicks, Digital, Audio, Common Artifacts]
 lang: 日本語
 ---

--- a/_artifacts/jp/lengthwise_tape_expansion_or_shrinkage.md
+++ b/_artifacts/jp/lengthwise_tape_expansion_or_shrinkage.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Lengthwise Tape Expansion or Shrinkage
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Tape Error]
 lang: 日本語
 ---

--- a/_artifacts/jp/level_clamping.md
+++ b/_artifacts/jp/level_clamping.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Level Clamping
-categories: video analog
+categories:  ビデオ アナログ  
 namevar: [clipping, legalizing]
 tags: [Video, Transfer Artifact, Station Qualification, Digitization, Levels, Waveform]
 lang: 日本語

--- a/_artifacts/jp/long_play.md
+++ b/_artifacts/jp/long_play.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Long Play
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Video, Analog, LP, Long Play, Operator Error]
 formats: [VHS, Betamax, DV]
 lang: 日本語

--- a/_artifacts/jp/loss_of_color_lock.md
+++ b/_artifacts/jp/loss_of_color_lock.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Loss of Color Lock
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Color, PAL, Color lock, Operator Error, Device Error]
 formats: [U-matic]
 lang: 日本語

--- a/_artifacts/jp/low_rf.md
+++ b/_artifacts/jp/low_rf.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Low RF
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, RF, Cleaning]
 lang: 日本語
 ---

--- a/_artifacts/jp/luminance_noise.md
+++ b/_artifacts/jp/luminance_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Luminance Noise
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Luminance, Noise, Cable, Cleaning]
 lang: 日本語
 ---

--- a/_artifacts/jp/missing_frames.md
+++ b/_artifacts/jp/missing_frames.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Missing Frames
-categories: film analog
+categories:  フィルム アナログ  
 tags: [Analog, Film]
 lang: 日本語
 ---

--- a/_artifacts/jp/moire_effect.md
+++ b/_artifacts/jp/moire_effect.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Moiré Effect
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Interference, Video, Analog]
 lang: 日本語
 ---

--- a/_artifacts/jp/mosquito_noise.md
+++ b/_artifacts/jp/mosquito_noise.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Mosquito Noise
-categories: video digital
+categories:  ビデオ デジタル
 tags: [Digital, Video, Noise, MPEG, DV25, Discrete Cosine Transform]
 lang: 日本語
 ---

--- a/_artifacts/jp/muffled_sound.md
+++ b/_artifacts/jp/muffled_sound.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Muffled Sound
-categories: audio analog
+categories:  オーディオ  アナログ  
 namevar: [Azimuth Error]
 tags: [Audio, Analog, Azimuth, Error, Frequency Loss, Playback Adjustment, Media Failure, Media Damage, Oxide Out, Common Artifacts]
 lang: 日本語

--- a/_artifacts/jp/noise_reduction.md
+++ b/_artifacts/jp/noise_reduction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Noise Reduction
-categories: audio analog
+categories:  オーディオ  アナログ  
 namevar: [Dolby, dbx, Compander]
 tags: [Analog, Audio, Cassette, Noise, Open Reel Tape]
 lang: 日本語

--- a/_artifacts/jp/oversaturation.md
+++ b/_artifacts/jp/oversaturation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Oversaturation
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Cable, Chrominance, Color, Hue, Operator Error, Tape Error, Time Base Corrector, Common Artifacts]
 lang: 日本語
 ---

--- a/_artifacts/jp/pcm_f1_Audio_without_adaptor.md
+++ b/_artifacts/jp/pcm_f1_Audio_without_adaptor.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: PCM F1 Audio without Adaptor
-categories: audio digital
+categories:  オーディオ デジタル
 namevar: [PCM, F1, digital audio]
 tags: [Audio, Digital, U-matic, Betamax]
 formats: [U-matic, Betamax]

--- a/_artifacts/jp/phantom_frames.md
+++ b/_artifacts/jp/phantom_frames.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Phantom Frames
-categories: film analog
+categories:  フィルム アナログ  
 tags: [Analog, Film]
 formats: [Film]
 lang: 日本語

--- a/_artifacts/jp/pilot_tone.md
+++ b/_artifacts/jp/pilot_tone.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Pilot Tone
-categories: audio video film analog
+categories:  オーディオ ビデオ フィルム アナログ
 namevar: [Double System Sound]
 tags: [Analog, Audio, Video, Film, Open Reel Tape, Hum, Synchronization]
 lang: 日本語

--- a/_artifacts/jp/poor_yc_decoding.md
+++ b/_artifacts/jp/poor_yc_decoding.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Poor Y/C Decoding (S-Video crosstalk)
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Cable, Production Error]
 lang: 日本語
 ---

--- a/_artifacts/jp/print-through.md
+++ b/_artifacts/jp/print-through.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Print-through
-categories: audio analog
+categories:  オーディオ  アナログ  
 namevar: [Interlayer Transfer]
 tags: [Analog, Audio, Pre-echo, Post-echo, Rewinding, Magnetostrictive Action]
 lang: 日本語

--- a/_artifacts/jp/quadrants_misalignment.md
+++ b/_artifacts/jp/quadrants_misalignment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Quadrants Misalignment
-categories: film analog
+categories:  フィルム アナログ  
 tags: [Analog, Film]
 formats: [Film]
 lang: 日本語

--- a/_artifacts/jp/ringing.md
+++ b/_artifacts/jp/ringing.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Ringing
-categories: video analog
+categories:  ビデオ アナログ  
 namevar: [Overshoot]
 tags: [Analog, Video, Cable, Time Base Corrector]
 formats: [U-matic]

--- a/_artifacts/jp/scratches.md
+++ b/_artifacts/jp/scratches.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Scratches
-categories: film analog
+categories:  フィルム アナログ  
 tags: [Analog, Film]
 formats: [Film]
 lang: 日本語

--- a/_artifacts/jp/scratches_and_tape_wear.md
+++ b/_artifacts/jp/scratches_and_tape_wear.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Damage, Scratches and Tape Wear
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Audio, Abrasion, Gouging, Media Damage, Tape Error, Common Artifacts]
 formats: [Betamax, U-matic, VHS]
 lang: 日本語

--- a/_artifacts/jp/sdi_spike.md
+++ b/_artifacts/jp/sdi_spike.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: SDI Spike
-categories: video digital
+categories:  ビデオ デジタル
 tags: [Video, Digital]
 lang: 日本語
 ---

--- a/_artifacts/jp/skew_error.md
+++ b/_artifacts/jp/skew_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Skew Error
-categories: video analog
+categories:  ビデオ アナログ  
 namevar: [Flagging]
 tags: [Analog, Video, Skew, Error, Time Base Corrector, Expansion, Shrinkage, Media Damage, Device Error, Tape Error, Common Artifacts]
 formats: [U-matic]

--- a/_artifacts/jp/smpte_time_code.md
+++ b/_artifacts/jp/smpte_time_code.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: SMPTE Time Code
-categories: audio video film
+categories:  オーディオ ビデオ フィルム
 tags: [Analog, Audio, Video, Film, Pulse, Synchronization, Open Reel Tape]
 lang: 日本語
 ---

--- a/_artifacts/jp/soft_binder_syndrome.md
+++ b/_artifacts/jp/soft_binder_syndrome.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Soft Binder Syndrome
-categories: audio analog
+categories:  オーディオ  アナログ  
 namevar: [Hydrolysis, Sticky Shed Syndrome, Loss of Lubricant]
 tags: [Analog, Audio, Open Reel Tape, Media Failure, Frequency Loss, Baking, Common Artifacts]
 lang: 日本語

--- a/_artifacts/jp/sparkle.md
+++ b/_artifacts/jp/sparkle.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Sparkle
-categories: film analog
+categories:  フィルム アナログ  
 tags: [Analog, Film]
 formats: [Film]
 lang: 日本語

--- a/_artifacts/jp/stiction.md
+++ b/_artifacts/jp/stiction.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Stiction
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Media Failure, Cleaning, Tape Error]
 lang: 日本語
 ---

--- a/_artifacts/jp/sub-sampling_artifact.md
+++ b/_artifacts/jp/sub-sampling_artifact.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Sub-sampling artifact
-categories: video digital
+categories:  ビデオ デジタル
 tags: [Digital, Video, DV25, Sub-sampling]
 lang: 日本語
 ---

--- a/_artifacts/jp/subcarrier_phase_error.md
+++ b/_artifacts/jp/subcarrier_phase_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Subcarrier Phase Error
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Phase, Hue, Operator Error, Device Error, Common Artifacts]
 lang: 日本語
 ---

--- a/_artifacts/jp/sync_loss.md
+++ b/_artifacts/jp/sync_loss.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Sync Loss
-categories: video analog
+categories:  ビデオ アナログ  
 namevar: [Roll]
 tags: [Analog, Video, Synchronization]
 lang: 日本語

--- a/_artifacts/jp/tape_deformation.md
+++ b/_artifacts/jp/tape_deformation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Tape Deformation
-categories: video audio analog
+categories:  オーディオ ビデオ アナログ
 tags: [Analog, Video, Audio, Deformation, Edge curl, Curvature error, Step pack, Popped strand, Flange pack, Windowing, Spoking, Media Damage]
 lang: 日本語
 ---

--- a/_artifacts/jp/tbc_processing_artifact.md
+++ b/_artifacts/jp/tbc_processing_artifact.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: TBC Processing Artifact
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Time Base Corrector, Processing Artifact]
 lang: 日本語
 ---

--- a/_artifacts/jp/time_base_error.md
+++ b/_artifacts/jp/time_base_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Time Base Error
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Time Base Corrector, Common Artifacts]
 lang: 日本語
 ---

--- a/_artifacts/jp/tracking_error.md
+++ b/_artifacts/jp/tracking_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Tracking Error
-categories: video analog
+categories:  ビデオ アナログ  
 namevar: [Mistracking]
 tags: [Analog, Video, Tracking Error, Common Artifacts]
 formats: [Betamax, VHS]

--- a/_artifacts/jp/undersaturation.md
+++ b/_artifacts/jp/undersaturation.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Undersaturation
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Undersaturation, Chrominance, Common Artifacts]
 formats: [VHS, U-matic]
 lang: 日本語

--- a/_artifacts/jp/vacuum_guide_adjustment_error.md
+++ b/_artifacts/jp/vacuum_guide_adjustment_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vacuum Guide Adjustment Error
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Video, Analog, 2-inch Quad, Time Base Corrector, Playback Adjustment, Open Reel Tape]
 formats: [2" Quad]
 lang: 日本語

--- a/_artifacts/jp/venetian-blind_effect.md
+++ b/_artifacts/jp/venetian-blind_effect.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Venetian-blind Effect
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, PAL, Time Base Corrector, Color]
 lang: 日本語
 ---

--- a/_artifacts/jp/vertical_pixel_misalignment.md
+++ b/_artifacts/jp/vertical_pixel_misalignment.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vertical Pixel Misalignment
-categories: film analog
+categories:  フィルム アナログ  
 tags: [Analog, Film]
 lang: 日本語
 ---

--- a/_artifacts/jp/vertical_smearing.md
+++ b/_artifacts/jp/vertical_smearing.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Vertical Smearing
-categories: digital video
+categories:  デジタル ビデオ 
 tags: [Digital, Video]
 lang: 日本語
 ---

--- a/_artifacts/jp/video_dropout.md
+++ b/_artifacts/jp/video_dropout.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Video Dropout
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Dropout, Common Artifacts]
 lang: 日本語
 ---

--- a/_artifacts/jp/video_head_clog.md
+++ b/_artifacts/jp/video_head_clog.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Video Head Clog
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Video, Analog, Media Failure, Cleaning, Head Clog, Common Artifacts]
 formats: [VHS, U-matic]
 lang: 日本語

--- a/_artifacts/jp/video_jitter.md
+++ b/_artifacts/jp/video_jitter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Video Jitter
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Video]
 lang: 日本語
 ---

--- a/_artifacts/jp/video_overwrite.md
+++ b/_artifacts/jp/video_overwrite.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Video Overwrite
-categories: video analog digital
+categories:  ビデオ アナログ デジタル
 tags: [Video]
 lang: 日本語
 ---

--- a/_artifacts/jp/visible_frame_line.md
+++ b/_artifacts/jp/visible_frame_line.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Visible Frame Line
-categories: film analog
+categories:  フィルム アナログ  
 tags: [Film]
 formats: [Film]
 lang: 日本語

--- a/_artifacts/jp/white_balance_error.md
+++ b/_artifacts/jp/white_balance_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: White Balance Error
-categories: video analog digital
+categories:  ビデオ アナログ デジタル
 tags: [Video, Analog, Digital]
 lang: 日本語
 ---

--- a/_artifacts/jp/wow_and_flutter.md
+++ b/_artifacts/jp/wow_and_flutter.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Wow and Flutter
-categories: audio analog
+categories:  オーディオ  アナログ  
 namevar: [Speed Fluctuation]
 tags: [Audio, Analog, Deck Failure, Speed Fluctuation, Pitch, Dying Batteries, Warble, Common Artifacts]
 lang: 日本語

--- a/_artifacts/jp/yc_delay_error.md
+++ b/_artifacts/jp/yc_delay_error.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: Y/C Delay Error
-categories: video analog
+categories:  ビデオ アナログ  
 tags: [Analog, Video, Y/C Delay Error]
 lang: 日本語
 ---

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -48,11 +48,12 @@
                     {% endif %} {% endfor %}
                 </ul>
             </div>
-            <div class="posts">
+            <!-- <div class="posts">
                 <h4>Browse by category</h4>
                 {% for tag in tags %}
-                <a class="category-tag" href="{{ site.baseurl }}/categories.html#{{ tag | slugify }}"> {{ tag }} </a> {% endfor %}
-            </div>
+                <a class="category-tag" href="{{ site.baseurl }}/categories.html#{{ tag | slugify }}"> {{ tag }} </a> 
+                {% endfor %}
+            </div> -->
 
             <div class="footer">
                 <span id="footer-links">

--- a/es/categories.md
+++ b/es/categories.md
@@ -10,8 +10,10 @@ order: 4
 
 {% assign rawtags = "" %}
 {% for post in site.artifacts %}
-  {% assign ttags = post.categories | join:'|' | append:'|' %}
-  {% assign rawtags = rawtags | append:ttags %}
+  {% if post.lang == page.lang %}
+    {% assign ttags = post.categories | join:'|' | append:'|' %}
+    {% assign rawtags = rawtags | append:ttags %}
+  {% endif %}
 {% endfor %}
 {% assign rawtags = rawtags | split:'|' | sort %}
 
@@ -36,15 +38,13 @@ order: 4
   <h2 id="{{ tag | slugify }}">{{ tag }}</h2>
   <ul>
    {% for artifact in site.artifacts %}
-     {% if artifact.lang == page.lang %}
-       {% if artifact.categories contains tag %}
+      {% if artifact.lang == page.lang and artifact.categories contains tag %}
        <li><h3>
          <a href="{{ site.baseurl }}{{ artifact.url }}">
          {{ artifact.title }}
          </a></h3>
        </li>
-       {% endif %}
-     {% endif %}
+      {% endif %}
    {% endfor %}
   </ul>
 {% endfor %}

--- a/fr/categories.md
+++ b/fr/categories.md
@@ -9,8 +9,10 @@ order: 4
 
 {% assign rawtags = "" %}
 {% for post in site.artifacts %}
-  {% assign ttags = post.categories | join:'|' | append:'|' %}
-  {% assign rawtags = rawtags | append:ttags %}
+  {% if post.lang == page.lang %}
+    {% assign ttags = post.categories | join:'|' | append:'|' %}
+    {% assign rawtags = rawtags | append:ttags %}
+  {% endif %}
 {% endfor %}
 {% assign rawtags = rawtags | split:'|' | sort %}
 
@@ -35,15 +37,13 @@ order: 4
   <h2 id="{{ tag | slugify }}">{{ tag }}</h2>
   <ul>
    {% for artifact in site.artifacts %}
-     {% if artifact.lang == page.lang %}
-       {% if artifact.categories contains tag %}
+      {% if artifact.lang == page.lang and artifact.categories contains tag %}
        <li><h3>
          <a href="{{ site.baseurl }}{{ artifact.url }}">
          {{ artifact.title }}
          </a></h3>
        </li>
-       {% endif %}
-     {% endif %}
+      {% endif %}
    {% endfor %}
   </ul>
 {% endfor %}

--- a/jp/categories.md
+++ b/jp/categories.md
@@ -9,8 +9,10 @@ order: 4
 
 {% assign rawtags = "" %}
 {% for post in site.artifacts %}
-  {% assign ttags = post.categories | join:'|' | append:'|' %}
-  {% assign rawtags = rawtags | append:ttags %}
+  {% if post.lang == page.lang %}
+    {% assign ttags = post.categories | join:'|' | append:'|' %}
+    {% assign rawtags = rawtags | append:ttags %}
+  {% endif %}
 {% endfor %}
 {% assign rawtags = rawtags | split:'|' | sort %}
 
@@ -35,15 +37,13 @@ order: 4
   <h2 id="{{ tag | slugify }}">{{ tag }}</h2>
   <ul>
    {% for artifact in site.artifacts %}
-     {% if artifact.lang == page.lang %}
-       {% if artifact.categories contains tag %}
+      {% if artifact.lang == page.lang and artifact.categories contains tag %}
        <li><h3>
          <a href="{{ site.baseurl }}{{ artifact.url }}">
          {{ artifact.title }}
          </a></h3>
        </li>
-       {% endif %}
-     {% endif %}
+      {% endif %}
    {% endfor %}
   </ul>
 {% endfor %}


### PR DESCRIPTION
This PR makes an update to each of the listed categories so that they represent browsing in each language.

One change: This temporarily disables the categories on the AVAA sidebar, which are still available under "Categories". 